### PR TITLE
docs: append red team engagement log entry

### DIFF
--- a/Attendance.md
+++ b/Attendance.md
@@ -58,3 +58,4 @@ CONFIDENTIALITY LEVEL: INTERNAL // AUDIT ONLY
 | 2026-02-26 16:13:44 UTC | Code: PER-AK | red-team-log-update-42 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | 014a5469 |
 | 2026-02-27 16:24:55 UTC | Code: BAH-AMAN | red-team-log-update-42 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | 67969fc0 |
 | 2026-02-28 16:23:05 UTC | Code: PER-AK | red-team-log-update-43 | LOG-UPDATE | Updated operational engagement log with latest audit entry | [INFO: SYSTEM STABLE] | d4cfaeed |
+| 2026-03-01 16:17:44 UTC | Code: TUA-H | red-team-log-update-44 | LOG-UPDATE | Updated operational engagement log with latest audit entry | [INFO: SYSTEM STABLE] | 25ddaf21 |


### PR DESCRIPTION
Appended a new entry to the Red Team Operational Engagement Log in `Attendance.md` per the specified audit requirements. The update increments the branch name to `red-team-log-update-44`, utilizes a randomized operative ID and hex signature, and correctly specifies the timestamp and log action details under the `[INFO: SYSTEM STABLE]` classification.

---
*PR created automatically by Jules for task [13612130796223252491](https://jules.google.com/task/13612130796223252491) started by @AgentHitmanFaris*