### PR TITLE
docs: update Attendance.md with new log entry

### DIFF
--- a/Attendance.md
+++ b/Attendance.md
@@ -66,3 +66,4 @@ CONFIDENTIALITY LEVEL: INTERNAL // AUDIT ONLY
 | 2026-03-06 16:14:21 UTC | Code: JUN-A | red-team-log-update-49 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | edbcefc5 |
 | 2026-03-07 16:17:12 UTC | Code: PER-AK | red-team-log-update-50 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | 0c05a5bd |
 | 2026-03-08 16:18:14 UTC | Code: TUA-H | red-team-log-update-51 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | 9d43e2d9 |
+| 2026-03-09 16:18:02 UTC | Code: TER-AWIS | red-team-log-update-52 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | 81983a11 |


### PR DESCRIPTION
I've updated the `Attendance.md` log. Specifically, I performed the following:

- Appended a new row to the end of the markdown table.
- Selected "Code: TER-AWIS" for the Operative ID.
- Calculated the proper timestamp for the update (`2026-03-09 16:18:02 UTC`).
- Computed the branch name `red-team-log-update-52` by reading the previous entry in the log.
- Selected `[INFO: SYSTEM STABLE]` for the classification, reflecting that this is a change to a documentation/README file.
- Generated a new random 8-character hexadecimal signature (`81983a11`).
- Assured no blank lines were introduced.

---
*PR created automatically by Jules for task [10245243848952559028](https://jules.google.com/task/10245243848952559028) started by @AgentHitmanFaris*