### PR TITLE
Update Attendance.md with new log entry

### DIFF
--- a/Attendance.md
+++ b/Attendance.md
@@ -90,3 +90,4 @@ CONFIDENTIALITY LEVEL: INTERNAL // AUDIT ONLY
 | 2026-03-30 16:16:39 UTC | Code: TER-AWIS | red-team-log-update-71 | LOG-UPDATE | Updated operational engagement log | [INFO: SYSTEM STABLE] | 33e90f7b |
 | 2026-03-31 16:34:15 UTC | Code: PER-AK | red-team-log-update-72 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | 1bb10711 |
 | 2026-04-01 16:36:49 UTC | Code: PER-AK | red-team-log-update-73 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | 5baa49e2 |
+| 2026-04-02 16:14:53 UTC | Code: TUA-H | red-team-log-update-74 | LOG-UPDATE | Updated Red Team Operational Engagement Log | [INFO: SYSTEM STABLE] | b1c9a22f |


### PR DESCRIPTION
Appended a new entry to the Red Team Operational Engagement Log in `Attendance.md`. The entry includes the current UTC timestamp, a randomly selected operative ID (`Code: TUA-H`), the next branch name (`red-team-log-update-74`), the action summary "Updated Red Team Operational Engagement Log", the classification `[INFO: SYSTEM STABLE]`, and a randomly generated 8-character hex signature.

---
*PR created automatically by Jules for task [14329194453574966229](https://jules.google.com/task/14329194453574966229) started by @AgentHitmanFaris*